### PR TITLE
fix(smart--contracts): change instantiate2 workflow

### DIFF
--- a/contracts/injective-auction-pool/src/contract.rs
+++ b/contracts/injective-auction-pool/src/contract.rs
@@ -9,7 +9,7 @@ use injective_auction::auction_pool::{Config, ExecuteMsg, InstantiateMsg, QueryM
 use crate::error::ContractError;
 use crate::executions::{self, settle_auction};
 use crate::helpers::{query_current_auction, validate_percentage};
-use crate::state::{Auction, BIDDING_BALANCE, CONFIG, CURRENT_AUCTION};
+use crate::state::{Auction, BIDDING_BALANCE, CONFIG, UNSETTLED_AUCTION};
 
 const CONTRACT_NAME: &str = "crates.io:injective-auction-pool";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -59,7 +59,7 @@ pub fn instantiate(
         })
         .collect();
 
-    CURRENT_AUCTION.save(
+    UNSETTLED_AUCTION.save(
         deps.storage,
         &Auction {
             basket,
@@ -72,9 +72,7 @@ pub fn instantiate(
     BIDDING_BALANCE.save(deps.storage, &Uint128::zero())?;
 
     // create a new denom for the current auction round
-    let msg = msg
-        .token_factory_type
-        .create_denom(env.contract.address.clone(), "0");
+    let msg = msg.token_factory_type.create_denom(env.contract.address.clone(), "0");
 
     Ok(Response::default().add_message(msg))
 }

--- a/contracts/injective-auction-pool/src/error.rs
+++ b/contracts/injective-auction-pool/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Decimal, OverflowError, StdError};
+use cosmwasm_std::{Decimal, Instantiate2AddressError, OverflowError, StdError};
 use cw_utils::PaymentError;
 use thiserror::Error;
 
@@ -46,4 +46,7 @@ pub enum ContractError {
 
     #[error("Overflow error: {0}")]
     OverflowError(#[from] OverflowError),
+
+    #[error("Instantiate address error: {0}")]
+    Instantiate2AddressError(#[from] Instantiate2AddressError),
 }

--- a/contracts/injective-auction-pool/src/state.rs
+++ b/contracts/injective-auction-pool/src/state.rs
@@ -5,9 +5,13 @@ use injective_auction::auction_pool::Config;
 
 #[cw_serde]
 pub struct Auction {
+    /// The coins in the basket being auctioned
     pub basket: Vec<Coin>,
+    /// The auction round number
     pub auction_round: u64,
+    /// A unique number that is used to create new token factory denoms
     pub lp_subdenom: u64,
+    /// The time when the auction will close
     pub closing_time: u64,
 }
 
@@ -18,6 +22,6 @@ pub const REWARD_VAULTS: Map<u128, Addr> = Map::new("reward_vaults");
 /// Available balance to be used for bidding
 pub const BIDDING_BALANCE: Item<Uint128> = Item::new("bidding_balance");
 /// Stores the current auction details
-pub const CURRENT_AUCTION: Item<Auction> = Item::new("current_auction");
+pub const UNSETTLED_AUCTION: Item<Auction> = Item::new("current_auction");
 /// Maps the auction round to the treasure chest contract address
 pub const TREASURE_CHEST_CONTRACTS: Map<u64, Addr> = Map::new("treasure_chest_contracts");


### PR DESCRIPTION
This PR fixes the Instantiate2 logic so now treasury chest contract addresses can be known at compile time.