### PR TITLE
fix(smart-contracts): refactor contract to address pfc comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
+ "cw-ownable",
  "cw-paginate-storage",
  "cw-storage-plus",
  "cw-utils",
@@ -522,6 +523,7 @@ version = "0.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-ownable",
  "osmosis-std-derive",
  "prost",
  "prost-types",

--- a/contracts/injective-auction-pool/Cargo.toml
+++ b/contracts/injective-auction-pool/Cargo.toml
@@ -37,6 +37,7 @@ prost = { workspace = true }
 cw-utils = { workspace = true }
 treasurechest = { workspace = true }
 cw-paginate-storage = { workspace = true }
+cw-ownable = { workspace = true }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }

--- a/contracts/injective-auction-pool/src/contract.rs
+++ b/contracts/injective-auction-pool/src/contract.rs
@@ -8,7 +8,7 @@ use crate::error::ContractError;
 use crate::executions::{self, settle_auction};
 use crate::helpers::{new_auction_round, validate_percentage};
 use crate::queries;
-use crate::state::{Whitelisted, CONFIG, WHITELISTED_ADDRESSES};
+use crate::state::{Whitelisted, CONFIG, FUNDS_LOCKED, WHITELISTED_ADDRESSES};
 
 const CONTRACT_NAME: &str = "crates.io:injective-auction-pool";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -55,6 +55,8 @@ pub fn instantiate(
             min_return: validate_percentage(msg.min_return)?,
         },
     )?;
+
+    FUNDS_LOCKED.save(deps.storage, &false)?;
 
     let (messages, attributes) = new_auction_round(deps, &env, info, None, None)?;
 

--- a/contracts/injective-auction-pool/src/contract.rs
+++ b/contracts/injective-auction-pool/src/contract.rs
@@ -1,6 +1,4 @@
-use std::str::FromStr;
-
-use cosmwasm_std::{entry_point, Addr, Coin, Uint128};
+use cosmwasm_std::{entry_point, to_json_binary, Addr};
 use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw2::set_contract_version;
 
@@ -8,9 +6,9 @@ use injective_auction::auction_pool::{Config, ExecuteMsg, InstantiateMsg, QueryM
 
 use crate::error::ContractError;
 use crate::executions::{self, settle_auction};
-use crate::helpers::{query_current_auction, validate_percentage};
+use crate::helpers::{new_auction_round, validate_percentage};
 use crate::queries;
-use crate::state::{Auction, BIDDING_BALANCE, CONFIG, UNSETTLED_AUCTION};
+use crate::state::CONFIG;
 
 const CONTRACT_NAME: &str = "crates.io:injective-auction-pool";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -25,6 +23,16 @@ pub fn instantiate(
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     let owner = deps.api.addr_validate(&msg.owner.unwrap_or(info.sender.to_string()))?;
+    cw_ownable::initialize_owner(deps.storage, deps.api, Some(owner.to_string().as_str()))?;
+
+    // Ensure that the contract is funded with at least the minimum balance
+    let amount = cw_utils::must_pay(&info, &msg.native_denom)?;
+    if amount < msg.min_balance {
+        return Err(ContractError::InsufficientFunds {
+            native_denom: msg.native_denom,
+            min_balance: msg.min_balance,
+        });
+    }
 
     let whitelisted_addresses = msg
         .whitelisted_addresses
@@ -35,8 +43,8 @@ pub fn instantiate(
     CONFIG.save(
         deps.storage,
         &Config {
-            owner,
             native_denom: msg.native_denom,
+            min_balance: msg.min_balance,
             token_factory_type: msg.token_factory_type.clone(),
             rewards_fee: validate_percentage(msg.rewards_fee)?,
             rewards_fee_addr: deps.api.addr_validate(&msg.rewards_fee_addr)?,
@@ -47,42 +55,12 @@ pub fn instantiate(
         },
     )?;
 
-    // fetch current auction details and save them in the contract state
-    let current_auction_round_response = query_current_auction(deps.as_ref())?;
-
-    let auction_round = current_auction_round_response
-        .auction_round
-        .ok_or(ContractError::CurrentAuctionQueryError)?;
-
-    let basket = current_auction_round_response
-        .amount
-        .iter()
-        .map(|coin| Coin {
-            amount: Uint128::from_str(&coin.amount).expect("Failed to parse coin amount"),
-            denom: coin.denom.clone(),
-        })
-        .collect();
-
-    UNSETTLED_AUCTION.save(
-        deps.storage,
-        &Auction {
-            basket,
-            auction_round,
-            lp_subdenom: 1,
-            closing_time: current_auction_round_response.auction_closing_time(),
-        },
-    )?;
-
-    BIDDING_BALANCE.save(deps.storage, &Uint128::zero())?;
-
-    // create a new denom for the current auction round
-    let msg = msg.token_factory_type.create_denom(env.contract.address.clone(), "1");
+    let (messages, attributes) = new_auction_round(deps, &env, info, None, None)?;
 
     Ok(Response::default()
-        .add_message(msg)
+        .add_messages(messages)
         .add_attribute("action", "instantiate")
-        .add_attribute("auction_round", auction_round.to_string())
-        .add_attribute("lp_subdenom", "1"))
+        .add_attributes(attributes))
 }
 
 #[entry_point]
@@ -94,7 +72,6 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::UpdateConfig {
-            owner,
             rewards_fee,
             rewards_fee_addr,
             whitelist_addresses,
@@ -104,13 +81,16 @@ pub fn execute(
             deps,
             env,
             info,
-            owner,
             rewards_fee,
             rewards_fee_addr,
             whitelist_addresses,
             min_next_bid_increment_rate,
             min_return,
         ),
+        ExecuteMsg::UpdateOwnership(action) => {
+            cw_ownable::update_ownership(deps, &env.block, &info.sender, action)?;
+            Ok(Response::default())
+        },
         ExecuteMsg::TryBid {
             auction_round,
             basket_value,
@@ -132,6 +112,10 @@ pub fn execute(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => queries::query_config(deps),
+        QueryMsg::Ownership {} => {
+            let ownership = cw_ownable::get_ownership(deps.storage)?;
+            to_json_binary(&ownership)
+        },
         QueryMsg::TreasureChestContracts {
             start_after,
             limit,

--- a/contracts/injective-auction-pool/src/contract.rs
+++ b/contracts/injective-auction-pool/src/contract.rs
@@ -127,5 +127,6 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             limit,
         } => queries::query_treasure_chest_contracts(deps, start_after, limit),
         QueryMsg::BiddingBalance {} => queries::query_bidding_balance(deps),
+        QueryMsg::FundsLocked {} => to_json_binary(&FUNDS_LOCKED.load(deps.storage)?),
     }
 }

--- a/contracts/injective-auction-pool/src/error.rs
+++ b/contracts/injective-auction-pool/src/error.rs
@@ -1,4 +1,5 @@
-use cosmwasm_std::{Decimal, Instantiate2AddressError, OverflowError, StdError};
+use cosmwasm_std::{Decimal, Instantiate2AddressError, OverflowError, StdError, Uint128};
+use cw_ownable::OwnershipError;
 use cw_utils::PaymentError;
 use thiserror::Error;
 
@@ -49,4 +50,19 @@ pub enum ContractError {
 
     #[error("Instantiate address error: {0}")]
     Instantiate2AddressError(#[from] Instantiate2AddressError),
+
+    #[error("Missing auction winner")]
+    MissingAuctionWinner,
+
+    #[error("Missing auction winning bid")]
+    MissingAuctionWinningBid,
+
+    #[error("Insufficient funds. Must deposit at least {min_balance} {native_denom} to instantiate the contract")]
+    InsufficientFunds {
+        native_denom: String,
+        min_balance: Uint128,
+    },
+
+    #[error(transparent)]
+    Ownership(#[from] OwnershipError),
 }

--- a/contracts/injective-auction-pool/src/error.rs
+++ b/contracts/injective-auction-pool/src/error.rs
@@ -65,4 +65,14 @@ pub enum ContractError {
 
     #[error(transparent)]
     Ownership(#[from] OwnershipError),
+
+    #[error("Address already whitelisted: {address}")]
+    AddressAlreadyWhitelisted {
+        address: String,
+    },
+
+    #[error("Address not whitelisted: {address}")]
+    AddressNotWhitelisted {
+        address: String,
+    },
 }

--- a/contracts/injective-auction-pool/src/helpers.rs
+++ b/contracts/injective-auction-pool/src/helpers.rs
@@ -1,6 +1,252 @@
-use crate::ContractError;
-use cosmwasm_std::{Decimal, Deps, QueryRequest};
+use std::str::FromStr;
+
+use crate::{
+    state::{Auction, BIDDING_BALANCE, CONFIG, TREASURE_CHEST_CONTRACTS, UNSETTLED_AUCTION},
+    ContractError,
+};
+use cosmwasm_std::{
+    attr, instantiate2_address, to_json_binary, Addr, Attribute, BankMsg, Binary, CodeInfoResponse,
+    Coin, CosmosMsg, Decimal, Deps, DepsMut, Env, MessageInfo, OverflowError, QueryRequest,
+    Uint128, WasmMsg,
+};
 use injective_auction::auction::QueryCurrentAuctionBasketResponse;
+
+/// Starts a new auction
+pub(crate) fn new_auction_round(
+    deps: DepsMut,
+    env: &Env,
+    info: MessageInfo,
+    auction_winner: Option<String>,
+    auction_winning_bid: Option<Uint128>,
+) -> Result<(Vec<CosmosMsg>, Vec<Attribute>), ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+
+    // fetch current auction details and save them in the contract state
+    let current_auction_round_response = query_current_auction(deps.as_ref())?;
+
+    let current_auction_round = current_auction_round_response
+        .auction_round
+        .ok_or(ContractError::CurrentAuctionQueryError)?;
+
+    let current_basket = current_auction_round_response
+        .amount
+        .iter()
+        .map(|coin| Coin {
+            amount: Uint128::from_str(&coin.amount).expect("Failed to parse coin amount"),
+            denom: coin.denom.clone(),
+        })
+        .collect();
+
+    let unsettled_auction = UNSETTLED_AUCTION.may_load(deps.storage)?;
+
+    let mut attributes = vec![];
+    let mut messages = vec![];
+
+    match unsettled_auction {
+        Some(unsettled_auction) => {
+            let auction_winner = auction_winner.ok_or(ContractError::MissingAuctionWinner {})?;
+            let auction_winning_bid =
+                auction_winning_bid.ok_or(ContractError::MissingAuctionWinningBid {})?;
+            // the contract won the auction
+            // NOTE: this is assuming the bot is sending the correct data about the winner of the previous auction
+            // currently there's no way to query the auction module directly to get this information
+            if deps.api.addr_validate(&auction_winner)? == env.contract.address {
+                // update LP subdenom for the next auction round (increment by 1)
+                let new_subdenom = unsettled_auction.lp_subdenom.checked_add(1).ok_or(
+                    ContractError::OverflowError(OverflowError {
+                        operation: cosmwasm_std::OverflowOperation::Add,
+                        operand1: unsettled_auction.lp_subdenom.to_string(),
+                        operand2: 1.to_string(),
+                    }),
+                )?;
+
+                let unsettled_basket = unsettled_auction.basket;
+                let mut basket_fees = vec![];
+                let mut basket_to_treasure_chest = vec![];
+
+                // add the unused bidding balance to the basket to be redeemed later
+                // TODO: should this be taxed though? if not, move after the for loop
+                let remaining_bidding_balance =
+                    BIDDING_BALANCE.load(deps.storage)?.checked_sub(auction_winning_bid)?;
+
+                if remaining_bidding_balance > Uint128::zero() {
+                    basket_to_treasure_chest.push(Coin {
+                        denom: config.native_denom.clone(),
+                        amount: remaining_bidding_balance,
+                    });
+                }
+
+                // split the basket, taking the rewards fees into account
+                for coin in unsettled_basket.iter() {
+                    let fee = coin.amount * config.rewards_fee;
+                    basket_fees.push(Coin {
+                        denom: coin.denom.clone(),
+                        amount: fee,
+                    });
+                    basket_to_treasure_chest.push(Coin {
+                        denom: coin.denom.clone(),
+                        amount: coin.amount.checked_sub(fee)?,
+                    });
+                }
+
+                // reset the bidding balance to 0 if we won, otherwise keep the balance for the next round
+                BIDDING_BALANCE.save(deps.storage, &Uint128::zero())?;
+
+                let mut messages: Vec<CosmosMsg> = vec![];
+
+                // transfer corresponding tokens to the rewards fee address
+                messages.push(CosmosMsg::Bank(BankMsg::Send {
+                    to_address: config.rewards_fee_addr.to_string(),
+                    amount: basket_fees,
+                }));
+
+                // instantiate a treasury chest contract and get the future contract address
+                let creator = deps.api.addr_canonicalize(env.contract.address.as_str())?;
+                let code_id = config.treasury_chest_code_id;
+
+                let CodeInfoResponse {
+                    code_id: _,
+                    creator: _,
+                    checksum,
+                    ..
+                } = deps.querier.query_wasm_code_info(code_id)?;
+
+                let seed = format!(
+                    "{}{}{}",
+                    unsettled_auction.auction_round,
+                    info.sender.into_string(),
+                    env.block.height
+                );
+                let salt = Binary::from(seed.as_bytes());
+
+                let treasure_chest_address =
+                    Addr::unchecked(instantiate2_address(&checksum, &creator, &salt)?.to_string());
+
+                let denom = format!(
+                    "factory/{}/auction.{}",
+                    env.contract.address.to_string(),
+                    unsettled_auction.lp_subdenom
+                );
+
+                messages.push(CosmosMsg::Wasm(WasmMsg::Instantiate2 {
+                    admin: Some(env.contract.address.to_string()),
+                    code_id,
+                    label: format!(
+                        "Treasure chest for auction round {}",
+                        unsettled_auction.auction_round
+                    ),
+                    msg: to_json_binary(&treasurechest::chest::InstantiateMsg {
+                        denom: config.native_denom.clone(),
+                        owner: env.contract.address.to_string(),
+                        notes: denom.clone(),
+                        token_factory: config.token_factory_type.to_string(),
+                        burn_it: Some(false),
+                    })?,
+                    funds: basket_to_treasure_chest,
+                    salt,
+                }));
+
+                TREASURE_CHEST_CONTRACTS.save(
+                    deps.storage,
+                    unsettled_auction.auction_round,
+                    &treasure_chest_address,
+                )?;
+
+                // transfer previous token factory's admin rights to the treasury chest contract
+                messages.push(config.token_factory_type.change_admin(
+                    env.contract.address.clone(),
+                    &denom,
+                    treasure_chest_address.clone(),
+                ));
+
+                // create a new denom for the current auction round
+                messages.push(config.token_factory_type.create_denom(
+                    env.contract.address.clone(),
+                    format!("auction.{}", new_subdenom).as_str(),
+                ));
+
+                let basket = current_auction_round_response
+                    .amount
+                    .iter()
+                    .map(|coin| Coin {
+                        amount: Uint128::from_str(&coin.amount)
+                            .expect("Failed to parse coin amount"),
+                        denom: coin.denom.clone(),
+                    })
+                    .collect();
+
+                UNSETTLED_AUCTION.save(
+                    deps.storage,
+                    &Auction {
+                        basket,
+                        auction_round: current_auction_round_response.auction_round(),
+                        lp_subdenom: new_subdenom,
+                        closing_time: current_auction_round_response.auction_closing_time(),
+                    },
+                )?;
+                attributes.push(attr(
+                    "settled_auction_round",
+                    unsettled_auction.auction_round.to_string(),
+                ));
+                attributes.push(attr("new_auction_round", current_auction_round.to_string()));
+                attributes.push(attr("treasure_chest_address", treasure_chest_address.to_string()));
+                attributes.push(attr("new_subdenom", format!("auction.{}", new_subdenom)));
+
+                return Ok((messages, attributes));
+            }
+            // the contract did NOT win the auction
+            else {
+                // save the current auction details to the contract state, keeping the previous LP subdenom
+                UNSETTLED_AUCTION.save(
+                    deps.storage,
+                    &Auction {
+                        basket: current_auction_round_response
+                            .amount
+                            .iter()
+                            .map(|coin| Coin {
+                                amount: Uint128::from_str(&coin.amount)
+                                    .expect("Failed to parse coin amount"),
+                                denom: coin.denom.clone(),
+                            })
+                            .collect(),
+                        auction_round: current_auction_round_response.auction_round(),
+                        lp_subdenom: unsettled_auction.lp_subdenom,
+                        closing_time: current_auction_round_response.auction_closing_time(),
+                    },
+                )?;
+                attributes.push(attr(
+                    "settled_auction_round",
+                    unsettled_auction.auction_round.to_string(),
+                ));
+                attributes.push(attr("new_auction_round", current_auction_round.to_string()));
+                return Ok((messages, attributes));
+            }
+        },
+        // should only happen on instantiation, initialize LP subdenom & bidding balance to 0
+        None => {
+            UNSETTLED_AUCTION.save(
+                deps.storage,
+                &Auction {
+                    basket: current_basket,
+                    auction_round: current_auction_round_response.auction_round(),
+                    lp_subdenom: 0,
+                    closing_time: current_auction_round_response.auction_closing_time(),
+                },
+            )?;
+
+            BIDDING_BALANCE.save(deps.storage, &Uint128::zero())?;
+
+            // create a new denom for the current auction round
+            messages.push(
+                config.token_factory_type.create_denom(env.contract.address.clone(), "auction.0"),
+            );
+
+            attributes.push(attr("new_auction_round", current_auction_round.to_string()));
+            attributes.push(attr("lp_subdenom", "auction.0"));
+            return Ok((messages, attributes));
+        },
+    }
+}
 
 /// Validates the rewards fee
 pub(crate) fn validate_percentage(percentage: Decimal) -> Result<Decimal, ContractError> {

--- a/contracts/injective-auction-pool/src/queries.rs
+++ b/contracts/injective-auction-pool/src/queries.rs
@@ -1,15 +1,28 @@
 use cosmwasm_std::{to_json_binary, Binary, Deps, StdResult};
 use injective_auction::auction_pool::{
     BiddingBalanceResponse, ConfigResponse, TreasureChestContractsResponse,
+    WhitelistedAddressesResponse,
 };
 
-use crate::state::{BIDDING_BALANCE, CONFIG, TREASURE_CHEST_CONTRACTS};
+use crate::state::{BIDDING_BALANCE, CONFIG, TREASURE_CHEST_CONTRACTS, WHITELISTED_ADDRESSES};
 
 pub fn query_config(deps: Deps) -> StdResult<Binary> {
     to_json_binary(&ConfigResponse {
         config: CONFIG.load(deps.storage)?,
     })
 }
+
+pub fn query_whitelisted_addresses(deps: Deps) -> StdResult<Binary> {
+    let whitelisted_addresses: StdResult<Vec<String>> = WHITELISTED_ADDRESSES
+        .keys(deps.storage, None, None, cosmwasm_std::Order::Ascending)
+        .map(|item| item.map(|addr| addr.to_string()))
+        .collect();
+
+    to_json_binary(&WhitelistedAddressesResponse {
+        addresses: whitelisted_addresses?,
+    })
+}
+
 pub fn query_treasure_chest_contracts(
     deps: Deps,
     start_after: Option<u64>,

--- a/contracts/injective-auction-pool/src/state.rs
+++ b/contracts/injective-auction-pool/src/state.rs
@@ -15,9 +15,14 @@ pub struct Auction {
     pub closing_time: u64,
 }
 
+#[cw_serde]
+pub struct Whitelisted;
+
 /// Stores the config of the contract
 pub const CONFIG: Item<Config> = Item::new("config");
-/// Available balance to be used for bidding
+/// Whitelisted addresses that can call TryBid
+pub const WHITELISTED_ADDRESSES: Map<&Addr, Whitelisted> = Map::new("whitelisted_addresses");
+/// Stores the available balance that can be used for bidding
 pub const BIDDING_BALANCE: Item<Uint128> = Item::new("bidding_balance");
 /// Stores the current auction details
 pub const UNSETTLED_AUCTION: Item<Auction> = Item::new("usnsettled_auction");

--- a/contracts/injective-auction-pool/src/state.rs
+++ b/contracts/injective-auction-pool/src/state.rs
@@ -28,3 +28,5 @@ pub const BIDDING_BALANCE: Item<Uint128> = Item::new("bidding_balance");
 pub const UNSETTLED_AUCTION: Item<Auction> = Item::new("usnsettled_auction");
 /// Maps the auction round to the treasure chest contract address
 pub const TREASURE_CHEST_CONTRACTS: Map<u64, Addr> = Map::new("treasure_chest_contracts");
+/// Stores whether the funds can be withdrawn or not from the contract
+pub const FUNDS_LOCKED: Item<bool> = Item::new("funds_locked");

--- a/packages/injective_auction/Cargo.toml
+++ b/packages/injective_auction/Cargo.toml
@@ -21,6 +21,7 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 osmosis-std-derive = { workspace = true }
 treasurechest = { workspace = true }
+cw-ownable = { workspace = true }
 
 [dev-dependencies]
 protobuf = { workspace = true }

--- a/packages/injective_auction/src/auction_pool.rs
+++ b/packages/injective_auction/src/auction_pool.rs
@@ -1,11 +1,13 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Uint128};
+use cw_ownable::{cw_ownable_execute, cw_ownable_query};
 use treasurechest::tf::tokenfactory::TokenFactoryType;
 
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: Option<String>,
     pub native_denom: String,
+    pub min_balance: Uint128,
     pub token_factory_type: TokenFactoryType,
     pub rewards_fee: Decimal,
     pub rewards_fee_addr: String,
@@ -15,11 +17,10 @@ pub struct InstantiateMsg {
     pub min_return: Decimal,
 }
 
+#[cw_ownable_execute]
 #[cw_serde]
 pub enum ExecuteMsg {
     UpdateConfig {
-        /// New owner of the contract
-        owner: Option<String>,
         /// Percentage of the rewards that the rewards fee address will take. Value is between 0 and 1
         rewards_fee: Option<Decimal>,
         /// Address to receive the rewards fee
@@ -58,6 +59,7 @@ pub enum ExecuteMsg {
     },
 }
 
+#[cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
@@ -90,10 +92,10 @@ pub struct BiddingBalanceResponse {
 #[cw_serde]
 /// Config of the contract
 pub struct Config {
-    /// Owner of the contract
-    pub owner: Addr,
     /// Contract native denom
     pub native_denom: String,
+    /// Minimum balance to keep in the contract to create a new denoms
+    pub min_balance: Uint128,
     /// Token Factory Type for the contract
     pub token_factory_type: TokenFactoryType,
     /// Percentage of the rewards that the rewards fee address will take. Value is between 0 and 1

--- a/packages/injective_auction/src/auction_pool.rs
+++ b/packages/injective_auction/src/auction_pool.rs
@@ -78,6 +78,8 @@ pub enum QueryMsg {
     },
     #[returns(BiddingBalanceResponse)]
     BiddingBalance {},
+    #[returns(FundsLockedResponse)]
+    FundsLocked {},
 }
 
 #[cw_serde]
@@ -98,6 +100,11 @@ pub struct TreasureChestContractsResponse {
 #[cw_serde]
 pub struct BiddingBalanceResponse {
     pub bidding_balance: Uint128,
+}
+
+#[cw_serde]
+pub struct FundsLockedResponse {
+    pub funds_locked: bool,
 }
 
 #[cw_serde]

--- a/packages/injective_auction/src/auction_pool.rs
+++ b/packages/injective_auction/src/auction_pool.rs
@@ -25,12 +25,16 @@ pub enum ExecuteMsg {
         rewards_fee: Option<Decimal>,
         /// Address to receive the rewards fee
         rewards_fee_addr: Option<String>,
-        /// Addresses that are allowed to call TriBid on the copntract
-        whitelist_addresses: Option<Vec<String>>,
         /// Minimum next bid increment rate for the auction. Value is between 0 and 1
         min_next_bid_increment_rate: Option<Decimal>,
         /// The minimum return allowed in percentage. 5% means the contract cannot bid for more than 95% of the basket value
         min_return: Option<Decimal>,
+    },
+    /// Updates the whitelisted addresses that can bid on or settle the auction.
+    /// Remove is applied after add, so if an address is in both, it is removed
+    UpdateWhiteListedAddresses {
+        remove: Vec<String>,
+        add: Vec<String>,
     },
     /// Makes the contract bid on the auction. This is to be called by the any whitelisted address.
     TryBid {
@@ -65,6 +69,8 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     #[returns(ConfigResponse)]
     Config {},
+    #[returns(WhitelistedAddressesResponse)]
+    WhitelistedAddresses {},
     #[returns(TreasureChestContractsResponse)]
     TreasureChestContracts {
         start_after: Option<u64>,
@@ -77,6 +83,11 @@ pub enum QueryMsg {
 #[cw_serde]
 pub struct ConfigResponse {
     pub config: Config,
+}
+
+#[cw_serde]
+pub struct WhitelistedAddressesResponse {
+    pub addresses: Vec<String>,
 }
 
 #[cw_serde]
@@ -102,8 +113,6 @@ pub struct Config {
     pub rewards_fee: Decimal,
     /// Address to receive the rewards fee
     pub rewards_fee_addr: Addr,
-    /// Addresses that are allowed to bid on the auction
-    pub whitelisted_addresses: Vec<Addr>,
     /// Minimum next bid increment rate for the auction
     pub min_next_bid_increment_rate: Decimal,
     /// Treasury chest code id to instantiate a new treasury chest contract


### PR DESCRIPTION
This PR does the following:
1. Moves the start bid process from `Instantiate` to a separate function to be reused on `SettleAuction` and not repeat code.
2. Factory subdenom has now a more meaningful name `auction.<counter>` to have some context when checking wallet balances.
3. Modifies the way the contract owner is updated, using `cw_ownable`.
4. Changes the way it adds or removes whitelisted addresses to prevent overriding the list of whitelisted addresses by mistake.
5. `ExitPool` now checks if the contract has the funds locked and only allows people exiting the pool of they are not. Funds are locked on the first bid and unlocked when settling the auction.
6. Bidding balance tracks the amount of native funds that can be used for bidding, and makes sure there are always funds available for creating a new denom.
7. `Instantiate` now needs to send some native tokens that will stay in the contract for creating new denoms. The minimum balance is then saved into `Config`