### PR TITLE
fix: truncate instantiate2 address to have 20 bytes

### DIFF
--- a/contracts/injective-auction-pool/src/executions.rs
+++ b/contracts/injective-auction-pool/src/executions.rs
@@ -303,7 +303,6 @@ pub fn settle_auction(
 
     let current_auction_round_response = query_current_auction(deps.as_ref())?;
     let current_auction_round = current_auction_round_response.auction_round;
-    //        .ok_or(ContractError::CurrentAuctionQueryError)?;
 
     // prevents the contract from settling the auction if the auction round has not finished
     if current_auction_round.u64() == unsettled_auction.auction_round {

--- a/deploy/02-testnet-auction.txt
+++ b/deploy/02-testnet-auction.txt
@@ -51,6 +51,7 @@ injectived query wasm  cs smart $AUCTION_CONTRACT '{"current_auction_basket":{}}
 injectived query wasm  cs smart $AUCTION_CONTRACT '{"whitelisted_addresses":{}}' | jq
 injectived query wasm  cs smart $AUCTION_CONTRACT '{"funds_locked":{}}' | jq
 injectived query wasm  cs smart $AUCTION_CONTRACT '{"bidding_balance":{}}' | jq
+injectived query wasm  cs smart $AUCTION_CONTRACT '{"config":{}}' | jq
 
 # add address to whitelist
 injectived tx wasm execute $AUCTION_CONTRACT '{"update_white_listed_addresses":{"add":["inj12nn88vtuf893cpfkke23dszpr5uccqj2zqukt6"], "remove":[]}}' \
@@ -104,3 +105,6 @@ injectived tx wasm execute $AUCTION_CONTRACT '{"exit_pool":{}}' --from inj1cdugm
 
 # exit pool
 injectived tx wasm execute inj1kar690fes35rm0dx5zcjwt5pjhtvcf572w3ffe '{"exit_pool":{}}' --from inj1cdugmt5t0mgfsmfc99eyhe4fzps0937ae0jgqh --yes --gas-prices "160000000inj" --gas-adjustment 1.3 --gas auto --amount 102factory/$AUCTION_CONTRACT/auction.0 --node https://testnet.sentry.tm.injective.network:443 --output json --chain-id injective-888 | jq
+
+# settle auction
+injectived tx wasm execute $AUCTION_CONTRACT '{"settle_auction":{"auction_round":108, "auction_winner":"inj1dlyumvy7rfmq534hnh8et2ft58zpm0d84vjkfd", "auction_winning_bid": "7230370850000000000001"}}' --from inj1cdugmt5t0mgfsmfc99eyhe4fzps0937ae0jgqh --yes --gas-prices "160000000inj" --gas-adjustment 1.3 --gas auto --node https://testnet.sentry.tm.injective.network:443 --output json --chain-id injective-888 | jq


### PR DESCRIPTION
This PR fixes the length of the address being generated when using instantiate2_address, to have 20 bytes instead of the default 32 bytes.